### PR TITLE
fix(ci/actions): :construction: fix argument too long

### DIFF
--- a/.github/workflows/container-test.yaml
+++ b/.github/workflows/container-test.yaml
@@ -30,7 +30,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: "read"
-      pull-requests: "write"
 
     steps:
       - name: Checkout
@@ -53,40 +52,3 @@ jobs:
         run: |
           export PATH=$PATH:$CHROMEWEBDRIVER
           poetry run pytest --log-cli-level DEBUG --headless
-      - name: Fetch branches to compare
-        run: |
-          git fetch origin update-noplp-database main --depth=1
-
-      - name: Write or update summary comment in Pull Request #see https://github.com/actions/runner/issues/1733#issuecomment-2447036317
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const { execSync } = require('child_process');
-
-            const commentBody = execSync('poetry run python noplp/compare_changes.py').toString();
-
-
-            const {data: comments} = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.number,
-            })
-            // 41898282 is github-actions[bot] id.
-            const botComment = comments.find(comment => comment.user.id === 41898282)
-
-            if (!botComment) {
-              github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body: commentBody
-              })
-            } else {
-              github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: botComment.id,
-                body: commentBody
-              })
-            }

--- a/.github/workflows/container-test.yaml
+++ b/.github/workflows/container-test.yaml
@@ -62,9 +62,9 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const { exeSync } = require('child_process');
+            const { execSync } = require('child_process');
 
-            const commentBody = exeSync('poetry run python noplp/compare_changes.py').toString();
+            const commentBody = execSync('poetry run python noplp/compare_changes.py').toString();
 
 
             const {data: comments} = await github.rest.issues.listComments({

--- a/.github/workflows/container-test.yaml
+++ b/.github/workflows/container-test.yaml
@@ -30,6 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: "read"
+      pull-requests: "write"
 
     steps:
       - name: Checkout
@@ -52,3 +53,42 @@ jobs:
         run: |
           export PATH=$PATH:$CHROMEWEBDRIVER
           poetry run pytest --log-cli-level DEBUG --headless
+      - name: Fetch branches to compare
+        run: |
+          git fetch origin update-noplp-database main --depth=1
+
+      - name: Write or update summary comment in Pull Request #see https://github.com/actions/runner/issues/1733#issuecomment-2447036317
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const { exeSync } = require('child_process');
+
+            const commentBody = exeSync('poetry run python noplp/compare_changes.py'), {
+              cwd: '${{input.working_directory }}'
+            }).toString();
+
+
+            const {data: comments} = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.number,
+            })
+            // 41898282 is github-actions[bot] id.
+            const botComment = comments.find(comment => comment.user.id === 41898282)
+
+            if (!botComment) {
+              github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: commentBody
+              })
+            } else {
+              github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: commentBody
+              })
+            }

--- a/.github/workflows/container-test.yaml
+++ b/.github/workflows/container-test.yaml
@@ -64,9 +64,7 @@ jobs:
             const fs = require('fs');
             const { exeSync } = require('child_process');
 
-            const commentBody = exeSync('poetry run python noplp/compare_changes.py'), {
-              cwd: '${{input.working_directory }}'
-            }).toString();
+            const commentBody = exeSync('poetry run python noplp/compare_changes.py').toString();
 
 
             const {data: comments} = await github.rest.issues.listComments({

--- a/.github/workflows/scrapping.yaml
+++ b/.github/workflows/scrapping.yaml
@@ -53,24 +53,38 @@ jobs:
         run: |
           git fetch origin update-noplp-database main --depth=1
 
-      - name: Write comment source text using Python script
-        run: |
-          {
-            echo 'SCRIPT_OUTPUT<<EOF'
-            poetry run python noplp/compare_changes.py
-            echo EOF
-          } >> "$GITHUB_ENV"
-
-      - name: Write summary comment in Pull Request
+      - name: Write or update summary comment in Pull Request #see https://github.com/actions/runner/issues/1733#issuecomment-2447036317
         uses: actions/github-script@v7
         env:
-          COMMENT_BODY: ${{env.SCRIPT_OUTPUT}}
           PR_NUMBER: ${{steps.cpr.outputs.pull-request-number}}
         with:
           script: |
-            github.rest.issues.createComment({
-              issue_number: process.env.PR_NUMBER,
+            const fs = require('fs');
+            const { execSync } = require('child_process');
+
+            const commentBody = execSync('poetry run python noplp/compare_changes.py').toString();
+
+
+            const {data: comments} = await github.rest.issues.listComments({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: process.env.COMMENT_BODY
+              issue_number: process.env.PR_NUMBER,
             })
+            // 41898282 is github-actions[bot] id.
+            const botComment = comments.find(comment => comment.user.id === 41898282)
+
+            if (!botComment) {
+              github.rest.issues.createComment({
+                issue_number: process.env.PR_NUMBER,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: commentBody
+              })
+            } else {
+              github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: commentBody
+              })
+            }

--- a/noplp/compare_changes.py
+++ b/noplp/compare_changes.py
@@ -99,7 +99,7 @@ def diff(old_lyrics, new_lyrics):
 
     diff_files = "".join(difflib.unified_diff(expected, actual))
     # To avoid markdown interpretation fo single hyphen in comment by GitHub
-    diff_files = diff_files.replace("\n-\n", "\n\\-\n")
+    diff_files = diff_files.replace("\n-\n\n", "\n\\-\n\n").replace("\n+\n\n", "\n\\+\n\n")
 
     return diff_files
 

--- a/noplp/compare_changes.py
+++ b/noplp/compare_changes.py
@@ -98,6 +98,8 @@ def diff(old_lyrics, new_lyrics):
     actual = new_output.splitlines(1)
 
     diff_files = "".join(difflib.unified_diff(expected, actual))
+    # To avoid markdown interpretation fo single hyphen in comment by GitHub
+    diff_files = diff_files.replace("\n-\n", "\n\\-\n")
 
     return diff_files
 

--- a/noplp/compare_changes.py
+++ b/noplp/compare_changes.py
@@ -71,12 +71,12 @@ def compare_diff():
 
 def parse_song_print(song, unescape_new_line=False):
     print("<details>")
-    print(f"<summary>{song[0]}, de {song[1]}</summary>\n<pre><code>")
+    print(f"<summary>{song[0]}, de {song[1]}</summary>\n\n<pre><code>")
     if unescape_new_line:
         print(song[2].replace("\\n", "\n"))
     else:
         print(song[2])
-    print("</code></pre>\n</details>")
+    print("</code></pre>\n\n</details>")
 
 
 def diff(old_lyrics, new_lyrics):
@@ -98,8 +98,6 @@ def diff(old_lyrics, new_lyrics):
     actual = new_output.splitlines(1)
 
     diff_files = "".join(difflib.unified_diff(expected, actual))
-    # To avoid markdown interpretation fo single hyphen in comment by GitHub
-    diff_files = diff_files.replace("\n-\n\n", "\n\\-\n\n").replace("\n+\n\n", "\n\\+\n\n")
 
     return diff_files
 


### PR DESCRIPTION
* Instead of passing the comment text in an env var in the job, use node process execution to launch Python script.
* Fiw markdown escaping in collapsed sections, by adding new line spaces.